### PR TITLE
Add depart and return date times for transports

### DIFF
--- a/app/views/transports/_build.erb
+++ b/app/views/transports/_build.erb
@@ -1,6 +1,8 @@
 <% form_for @transport, @transport.new_record? ? "/h/#{@group.slug}/transports/new" : "/h/#{@group.slug}/transports/#{@transport.id}/edit", :class => 'form-horizontal' do |f| %>
   <%= f.text_block :name %>
   <%= f.text_area_block :description %>
+  <%= f.datetime_block :outward_leaves_at %>
+  <%= f.datetime_block :return_leaves_at %>
   <%= f.number_block :cost, :disabled => !@membership.admin? %>
   <%= f.number_block :capacity %>
   <%= f.submit_block destroy_url: "/h/#{@group.slug}/transports/#{@transport.id}/destroy" %>

--- a/app/views/transports/_transports.erb
+++ b/app/views/transports/_transports.erb
@@ -2,6 +2,8 @@
   <thead>
     <tr>
       <th>Transport</th>
+      <th>Outward depart time</th>
+      <th>Return depart time</th>
       <th>Cost</th>
       <th>Places taken</th>
       <th></th>
@@ -20,6 +22,12 @@
         <% end %>            
         <br />
         <%= transport.description %>        
+      </td>
+      <td>
+        <%= transport.outward_leaves_at %>
+      </td>
+      <td>
+        <%= transport.return_leaves_at %>
       </td>
       <td>
         <%=@group.currency_symbol%><%=transport.cost%>
@@ -62,4 +70,3 @@
 <% if params[:view] != 'names' %>
   <a onclick="$(this).closest('[data-pagelet-url]').attr('data-pagelet-url', '/h/<%=@group.slug%>/transports?view=names')" href="#" class="pagelet-trigger">Show names instead of pictures</a>
 <% end %>
-

--- a/models/transport.rb
+++ b/models/transport.rb
@@ -6,6 +6,8 @@ class Transport
   field :description, :type => String
   field :capacity, :type => Integer
   field :cost, :type => Integer
+  field :outward_leaves_at, :type => DateTime
+  field :return_leaves_at, :type => DateTime
   
   belongs_to :group, index: true
   belongs_to :account, index: true


### PR DESCRIPTION
Just a suggestion, but thought it would be clearer if we added the times for outward and return journeys as metadata, so that:

* It doesn't get forgotten about like it has with Ash Equinox
* It's clearer to scan through it on the index page
* Useful for filtering in the future if that's decided upon.

Also thought about adding the departing location as a separate field, maybe with post_code/lat/lng, but one step at a time ;-)